### PR TITLE
Mollie restore cart functionality back button browser

### DIFF
--- a/app/code/community/Mollie/Mpm/Model/Observer.php
+++ b/app/code/community/Mollie/Mpm/Model/Observer.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * Copyright (c) 2012-2014, Mollie B.V.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ * DAMAGE.
+ *
+ * @category    Mollie
+ * @package     Mollie_Mpm
+ * @author      Mollie B.V. (info@mollie.nl)
+ * @copyright   Copyright (c) 2012-2014 Mollie B.V. (https://www.mollie.nl)
+ * @license     http://www.opensource.org/licenses/bsd-license.php  Berkeley Software Distribution License (BSD-License 2)
+ *
+ **/
+
+class Mollie_Mpm_Model_Observer
+{
+    public function checkRestoreCartSession()
+    {
+        if(Mage::getSingleton('core/session')->getRestoreCart()) {
+            Mage::getSingleton('core/session')->unsRestoreCart();
+            $this->_restoreCart();
+            $this->_showException();
+            return;
+        }
+    }
+
+    /**
+     * Gets the current checkout session with order information
+     *
+     * @return Mage_Checkout_Model_Session
+     */
+    protected function _getCheckout ()
+    {
+        return Mage::getSingleton('checkout/session');
+    }
+
+    /**
+     * Put items back in the shopping cart
+     */
+    protected function _restoreCart ()
+    {
+        $session = $this->_getCheckout();
+
+        if (is_object($session) && $quoteId = $session->getMollieQuoteId())
+        {
+            $quote = Mage::getModel('sales/quote')->load($quoteId);
+
+            if ($quote->getId())
+            {
+                $quote->setIsActive(TRUE)->save();
+                $session->setQuoteId($quoteId);
+            }
+        }
+    }
+
+    /**
+     * Redirect to the checkout and give an error message
+     */
+    protected function _showException ()
+    {
+        Mage::app()->getResponse()->setRedirect(Mage::getUrl("checkout/cart"));
+    }
+}

--- a/app/code/community/Mollie/Mpm/controllers/ApiController.php
+++ b/app/code/community/Mollie/Mpm/controllers/ApiController.php
@@ -195,6 +195,8 @@ class Mollie_Mpm_ApiController extends Mage_Core_Controller_Front_Action
 				$payment->addTransaction(Mage_Sales_Model_Order_Payment_Transaction::TYPE_AUTH);
 				$order->setState(Mage_Sales_Model_Order::STATE_PROCESSING, Mage_Sales_Model_Order::STATE_PENDING_PAYMENT, $this->__(Mollie_Mpm_Model_Api::PAYMENT_FLAG_INPROGRESS), FALSE)->save();
 
+				Mage::getSingleton('core/session')->setRestoreCart(true);
+
 				$this->_redirectUrl($this->_api->getPaymentURL());
 			}
 			else
@@ -354,6 +356,14 @@ class Mollie_Mpm_ApiController extends Mage_Core_Controller_Front_Action
 	 */
 	public function returnAction ()
 	{
+		// Unset the restore cart session when returned properly (used for the cart restore when clicking the browser's back button during a payment).
+		if(Mage::getSingleton('core/session')->getRestoreCart()) {
+			Mage::getSingleton('core/session')->unsRestoreCart();
+		}
+
+		// Clear the cart just in case it has been restored by accident (e.g: user refreshes Magento in a seperate tab while still in payment screen).
+		$this->_clearCart();
+
 		// Get order_id and transaction_id from url (Ex: http://yourmagento.com/index.php/api/return?order_id=123 )
 		$orderId       = $this->getRequest()->getParam('order_id');
 		$transactionId = Mage::helper('mpm')->getTransactionIdByOrderId($orderId);
@@ -435,6 +445,24 @@ class Mollie_Mpm_ApiController extends Mage_Core_Controller_Front_Action
 			{
 				$quote->setIsActive(TRUE)->save();
 				$session->setQuoteId($quoteId);
+			}
+		}
+	}
+
+	/**
+	 * Clear the cart
+	 */
+	protected function _clearCart ()
+	{
+		$session = $this->_getCheckout();
+
+		if (is_object($session) && $quoteId = $session->getMollieQuoteId())
+		{
+			$quote = Mage::getModel('sales/quote')->load($quoteId);
+
+			if ($quote->getId())
+			{
+				$quote->setIsActive(false)->save();
 			}
 		}
 	}

--- a/app/code/community/Mollie/Mpm/etc/config.xml
+++ b/app/code/community/Mollie/Mpm/etc/config.xml
@@ -96,6 +96,16 @@
                 <template>mollie/page/payment_fail.phtml</template>
             </api_payment_fail>
         </layouts>
+        <events>
+            <controller_action_predispatch>
+                <observers>
+                    <mollie_check_restore_cart_session>
+                        <class>mpm/observer</class>
+                        <method>checkRestoreCartSession</method>
+                    </mollie_check_restore_cart_session>
+                </observers>
+            </controller_action_predispatch>
+        </events>
     </global>
 
     <frontend>

--- a/tests/unittests/controllers/ApiControllerPaymentActionTest.php
+++ b/tests/unittests/controllers/ApiControllerPaymentActionTest.php
@@ -39,10 +39,15 @@ class Mollie_Mpm_ApiControllerPaymentActionTest extends MagentoPlugin_TestCase
 	 */
 	protected $payment_model;
 
-    /**
-     * @var PHPUnit_Framework_MockObject_MockObject
-     */
-    protected $store;
+	/**
+	 * @var PHPUnit_Framework_MockObject_MockObject
+	 */
+	protected $core_session_singleton;
+
+	/**
+	 * @var PHPUnit_Framework_MockObject_MockObject
+	 */
+	protected $store;
 
 	const TRANSACTION_ID = "1bba1d8fdbd8103b46151634bdbe0a60";
 
@@ -67,9 +72,9 @@ class Mollie_Mpm_ApiControllerPaymentActionTest extends MagentoPlugin_TestCase
 		$this->mage->expects($this->any())
 			->method("Helper")
 			->will($this->returnValueMap(array(
-			array("mpm/data", $this->data_helper),
-			array("mpm/api", $this->api_helper),
-		)));
+				array("mpm/data", $this->data_helper),
+				array("mpm/api", $this->api_helper),
+			)));
 
 		$this->controller = $this->getMock("Mollie_Mpm_ApiController", array("getRequest", "_redirectUrl", "_showException", "_getCheckout"), array());
 
@@ -107,18 +112,33 @@ class Mollie_Mpm_ApiControllerPaymentActionTest extends MagentoPlugin_TestCase
 			->method("getOrderCurrencyCode")
 			->will($this->returnValue('EUR'));
 
+		$this->core_session_singleton   = $this->getMock("Mage_Core_Model_Session", array("setData", "getData", "setRestoreCart", "getRestoreCart"));
+
+		$this->core_session_singleton->expects($this->any())
+			->method("getRestoreCart")
+			->will($this->returnValue(true));
+
 		/*
 		 * Mage::getModel() method
 		 */
 		$this->mage->expects($this->any())
 			->method("getModel")
 			->will($this->returnValueMap(array(
-			array("mpm/api", $this->api_model),
-			array("sales/order", $this->order_model),
-			array("sales/order_payment", $this->payment_model),
-		)));
+				array("mpm/api", $this->api_model),
+				array("sales/order", $this->order_model),
+				array("sales/order_payment", $this->payment_model),
+			)));
 
-        $this->store = $this->getMock("stdClass", array("getBaseCurrencyCode", "getCurrentCurrencyCode", "getCode", "getBaseUrl"));
+		/*
+ 		 * Mage::getSingleton() method
+ 		 */
+		$this->mage->expects($this->any())
+			->method("getSingleton")
+			->will($this->returnValueMap(array(
+				array("core/session", $this->core_session_singleton),
+			)));
+
+		$this->store = $this->getMock("stdClass", array("getBaseCurrencyCode", "getCurrentCurrencyCode", "getCode", "getBaseUrl"));
 	}
 
 	protected function expectOrderIdInRequestPresent($present)
@@ -126,9 +146,9 @@ class Mollie_Mpm_ApiControllerPaymentActionTest extends MagentoPlugin_TestCase
 		$this->request->expects($this->any())
 			->method("getParam")
 			->will($this->returnValueMap(array(
-			array("order_id", $present ? self::ORDER_ID : NULL),
-			array("bank_id", self::BANK_ID),
-		)));
+				array("order_id", $present ? self::ORDER_ID : NULL),
+				array("bank_id", self::BANK_ID),
+			)));
 
 		if ($present)
 		{
@@ -144,25 +164,25 @@ class Mollie_Mpm_ApiControllerPaymentActionTest extends MagentoPlugin_TestCase
 		$this->data_helper->expects($this->atLeastOnce())
 			->method("getConfig")
 			->will($this->returnValueMap(array(
-			array("mollie", "description", "Bankafschrift order % deluxe"),
-		)));
+				array("mollie", "description", "Bankafschrift order % deluxe"),
+			)));
 	}
 
 	public function testPaymentSetupCorrectly()
 	{
 		$this->expectOrderIdInRequestPresent(TRUE);
 
-        $this->mage->expects($this->any())
-            ->method("app")
-            ->will($this->returnValue($this->mage));
+		$this->mage->expects($this->any())
+			->method("app")
+			->will($this->returnValue($this->mage));
 
-        $this->mage->expects($this->any())
-            ->method("getStore")
-            ->will($this->returnValue($this->store));
+		$this->mage->expects($this->any())
+			->method("getStore")
+			->will($this->returnValue($this->store));
 
-        $this->store->expects($this->any())
-            ->method("getCode")
-            ->will($this->returnValue('code'));
+		$this->store->expects($this->any())
+			->method("getCode")
+			->will($this->returnValue('code'));
 
 		$this->order_model->expects($this->exactly(2))
 			->method("setState")
@@ -216,6 +236,10 @@ class Mollie_Mpm_ApiControllerPaymentActionTest extends MagentoPlugin_TestCase
 		$this->api_helper->expects($this->atLeastOnce())
 			->method("getPaymentURL")
 			->will($this->returnValue(self::PAYMENT_URL));
+
+		$this->core_session_singleton->expects($this->once())
+			->method("setRestoreCart")
+			->with(TRUE);
 
 		$this->controller->expects($this->once())
 			->method("_redirectUrl")

--- a/tests/unittests/controllers/ApiControllerReturnActionTest.php
+++ b/tests/unittests/controllers/ApiControllerReturnActionTest.php
@@ -17,12 +17,7 @@ class Mollie_Mpm_ApiControllerReturnActionTest extends MagentoPlugin_TestCase
 	/**
 	 * @var PHPUnit_Framework_MockObject_MockObject
 	 */
-	protected $datahelper;
-
-	/**
-	 * @var PHPUnit_Framework_MockObject_MockObject
-	 */
-	protected $order;
+	protected $data_helper;
 
 	/**
 	 * @var PHPUnit_Framework_MockObject_MockObject
@@ -32,7 +27,12 @@ class Mollie_Mpm_ApiControllerReturnActionTest extends MagentoPlugin_TestCase
 	/**
 	 * @var PHPUnit_Framework_MockObject_MockObject
 	 */
-	protected $session;
+	protected $core_session_singleton;
+
+	/**
+	 * @var PHPUnit_Framework_MockObject_MockObject
+	 */
+	protected $checkout_session_singleton;
 
 	/**
 	 * @var PHPUnit_Framework_MockObject_MockObject
@@ -62,7 +62,7 @@ class Mollie_Mpm_ApiControllerReturnActionTest extends MagentoPlugin_TestCase
 			->method("getRequest")
 			->will($this->returnValue($this->request));
 
-		$this->datahelper  = $this->getMock("stdClass", array("getOrderIdByTransactionId", "getTransactionIdByOrderId", "getStatusById"));
+		$this->data_helper  = $this->getMock("stdClass", array("getOrderIdByTransactionId", "getTransactionIdByOrderId", "getStatusById"));
 
 		/*
 		 * Mage::Helper() method
@@ -70,12 +70,24 @@ class Mollie_Mpm_ApiControllerReturnActionTest extends MagentoPlugin_TestCase
 		$this->mage->expects($this->any())
 			->method("Helper")
 			->will($this->returnValueMap(array(
-			array("mpm", $this->datahelper),
-		)));
+				array("mpm", $this->data_helper),
+			)));
 
-		$this->order = $this->getMock("Mage_Sales_Model_Order", array("getData", "setPayment", "getGrandTotal", "getAllItems", "setState", "sendNewOrderEmail", "setEmailSent", "cancel", "save"));
+		$this->order_model = $this->getMock("Mage_Sales_Model_Order", array("getData", "setPayment", "getGrandTotal", "getAllItems", "setState", "sendNewOrderEmail", "setEmailSent", "cancel", "save", "load"));
 
-		$this->order_model   = $this->getMock("stdClass", array("load"));
+		$this->quote = $this->getMock("stdClass");
+
+		$this->core_session_singleton   = $this->getMock("Mage_Core_Model_Session", array("unsRestoreCart", "getRestoreCart"));
+
+		$this->core_session_singleton->expects($this->any())
+			->method("getRestoreCart")
+			->will($this->returnValue(true));
+
+		$this->checkout_session_singleton   = $this->getMock("Mage_Core_Model_Session", array("getQuote", "getMollieQuoteId"));
+
+		$this->checkout_session_singleton->expects($this->any())
+			->method("getQuote")
+			->will($this->returnValue($this->quote));
 
 		/*
 		 * Mage::getModel() method
@@ -83,24 +95,27 @@ class Mollie_Mpm_ApiControllerReturnActionTest extends MagentoPlugin_TestCase
 		$this->mage->expects($this->any())
 			->method("getModel")
 			->will($this->returnValueMap(array(
-			array("sales/order", $this->order_model),
-		)));
-
-		$this->session = $this->getMock("stdClass", array("getQuote", "getMollieQuoteId"));
-		$this->quote = $this->getMock("stdClass");
-
-		$this->session->expects($this->any())
-			->method("getQuote")
-			->will($this->returnValue($this->quote));
+				array("sales/order", $this->order_model),
+			)));
 
 		/*
-		 * Mage::getSingleton() method
-		 */
+   		 * Mage::getSingleton() method
+   		 */
 		$this->mage->expects($this->any())
 			->method("getSingleton")
 			->will($this->returnValueMap(array(
-			array("checkout/session", $this->session),
-		)));
+				array("core/session", $this->core_session_singleton),
+				array("checkout/session", $this->checkout_session_singleton),
+			)));
+	}
+
+	protected function expectSessionSingleton() {
+		$this->core_session_singleton->expects($this->once())
+			->method("getRestoreCart")
+			->will($this->returnValue(TRUE));
+
+		$this->core_session_singleton->expects($this->once())
+			->method("unsRestoreCart");
 	}
 
 	protected function expectOrderState($expected_state)
@@ -108,7 +123,7 @@ class Mollie_Mpm_ApiControllerReturnActionTest extends MagentoPlugin_TestCase
 		/*
 		 * Status must be checked with the order.
 		 */
-		$this->order->expects($this->once())
+		$this->order_model->expects($this->once())
 			->method("getData")
 			->with("status")
 			->will($this->returnValue($expected_state));
@@ -116,11 +131,11 @@ class Mollie_Mpm_ApiControllerReturnActionTest extends MagentoPlugin_TestCase
 
 	protected function expectsOrderModelCanBeloaded()
 	{
-		$this->datahelper->expects($this->any())
+		$this->data_helper->expects($this->any())
 			->method("getOrderIdByTransactionId")
 			->with(self::TRANSACTION_ID)
 			->will($this->returnValue(self::ORDER_ID));
-		$this->datahelper->expects($this->any())
+		$this->data_helper->expects($this->any())
 			->method("getTransactionIdByOrderId")
 			->with(self::ORDER_ID)
 			->will($this->returnValue(self::TRANSACTION_ID));
@@ -128,7 +143,7 @@ class Mollie_Mpm_ApiControllerReturnActionTest extends MagentoPlugin_TestCase
 
 	protected function expectOrderSaved()
 	{
-		$this->order->expects($this->once())
+		$this->order_model->expects($this->once())
 			->method("save");
 	}
 
@@ -137,23 +152,24 @@ class Mollie_Mpm_ApiControllerReturnActionTest extends MagentoPlugin_TestCase
 		/*
 		 * Put in the amounts
 		 */
-		$this->order->expects($this->atLeastOnce())
+		$this->order_model->expects($this->atLeastOnce())
 			->method("getGrandTotal")
 			->will($this->returnValue($string_amount)); // Is a string, for realsies.
 	}
 
 	public function testEverythingGoesGreat()
 	{
+		$this->expectSessionSingleton();
 
 		$this->expectsOrderModelCanBeloaded();
 
-		$this->datahelper->expects($this->once())
+		$this->data_helper->expects($this->once())
 			->method("getStatusById")
 			->with(self::TRANSACTION_ID)
 			->will($this->returnValue(array(
-			'bank_status' => Mollie_Mpm_Model_Api::STATUS_PAID,
-			'updated_at' => '2014-04-26',
-		)));
+				'bank_status' => Mollie_Mpm_Model_Api::STATUS_PAID,
+				'updated_at' => '2014-04-26',
+			)));
 
 		$this->quote->items_count = 0;
 
@@ -170,15 +186,17 @@ class Mollie_Mpm_ApiControllerReturnActionTest extends MagentoPlugin_TestCase
 
 	public function testPaymentPending()
 	{
+		$this->expectSessionSingleton();
+
 		$this->expectsOrderModelCanBeloaded();
 
-		$this->datahelper->expects($this->once())
+		$this->data_helper->expects($this->once())
 			->method("getStatusById")
 			->with(self::TRANSACTION_ID)
 			->will($this->returnValue(array(
-						'bank_status' => Mollie_Mpm_Model_Api::STATUS_PENDING,
-						'updated_at' => '2014-04-26',
-					)));
+				'bank_status' => Mollie_Mpm_Model_Api::STATUS_PENDING,
+				'updated_at' => '2014-04-26',
+			)));
 
 		$this->quote->items_count = 0;
 
@@ -195,15 +213,17 @@ class Mollie_Mpm_ApiControllerReturnActionTest extends MagentoPlugin_TestCase
 
 	public function testPaymentCancelled()
 	{
+		$this->expectSessionSingleton();
+
 		$this->expectsOrderModelCanBeloaded();
 
-		$this->datahelper->expects($this->once())
+		$this->data_helper->expects($this->once())
 			->method("getStatusById")
 			->with(self::TRANSACTION_ID)
 			->will($this->returnValue(array(
-						'bank_status' => Mollie_Mpm_Model_Api::STATUS_CANCELLED,
-						'updated_at' => '2014-04-26',
-					)));
+				'bank_status' => Mollie_Mpm_Model_Api::STATUS_CANCELLED,
+				'updated_at' => '2014-04-26',
+			)));
 
 		$this->controller->expects($this->once())
 			->method("_restoreCart");

--- a/tests/unittests/controllers/ApiControllerReturnActionTest.php
+++ b/tests/unittests/controllers/ApiControllerReturnActionTest.php
@@ -83,7 +83,7 @@ class Mollie_Mpm_ApiControllerReturnActionTest extends MagentoPlugin_TestCase
 			->method("getRestoreCart")
 			->will($this->returnValue(true));
 
-		$this->checkout_session_singleton   = $this->getMock("Mage_Core_Model_Session", array("getQuote", "getMollieQuoteId"));
+		$this->checkout_session_singleton   = $this->getMock("Mage_Checkout_Model_Session", array("getQuote", "getMollieQuoteId"));
 
 		$this->checkout_session_singleton->expects($this->any())
 			->method("getQuote")


### PR DESCRIPTION
Added a session for restoring the cart, this will be checked if the user does not finish or cancel the payment properly. Added an observer to the event 'controller_action_predispatch' to restore the cart if the session is set. On the returnAction it will unset the session as it has properly finished or canceled the payment.