### PR TITLE
Modman install fails and no shorthand php syntax

### DIFF
--- a/app/design/frontend/base/default/template/mollie/mpm/payment/form.phtml
+++ b/app/design/frontend/base/default/template/mollie/mpm/payment/form.phtml
@@ -34,18 +34,18 @@ $code = $this->getMethodCode();
 $method = $this->getMethodByCode($code);
 ?>
 <?php if (!empty($method->issuers) && ($listType = $this->getIssuerListType($code))): ?>
-    <ul class="form-list" id="payment_form_<?= $this->escapeHtml($code) ?>" style="display:none">
+    <ul class="form-list" id="payment_form_<?php echo $this->escapeHtml($code) ?>" style="display:none">
         <li>
-            <label for="<?= $code ?>_issuer">
-                <?= $this->getIssuerTitle($code); ?>
+            <label for="<?php echo $code ?>_issuer">
+                <?php echo $this->getIssuerTitle($code); ?>
             </label>
             <span class="input-box">
                 <?php if ($listType == 'dropdown'): ?>
-                    <select name="<?= $code; ?>_issuer" id="<?= $code; ?>_issuer" class="input-text">
-                        <option value=""><?= $this->__('Please select'); ?></option>
+                    <select name="<?php echo $code; ?>_issuer" id="<?php echo $code; ?>_issuer" class="input-text">
+                        <option value=""><?php echo $this->__('Please select'); ?></option>
                         <?php foreach ($method->issuers() as $issuer): ?>
-                            <option value="<?= htmlspecialchars($issuer->id); ?>">
-                                <?= htmlspecialchars($issuer->name); ?>
+                            <option value="<?php echo htmlspecialchars($issuer->id); ?>">
+                                <?php echo htmlspecialchars($issuer->name); ?>
                             </option>
                         <?php endforeach; ?>
                     </select>
@@ -54,9 +54,9 @@ $method = $this->getMethodByCode($code);
                     <ul>
                     <?php foreach ($method->issuers() as $issuer): ?>
                         <li>
-                            <input type="radio" name="<?= $code; ?>_issuer" value="<?= htmlspecialchars($issuer->id); ?>" id="issuer_<?= htmlspecialchars($issuer->id); ?>" class="radio">
-                            <img src="<?= $issuer->image->size2x; ?>" class="payment-issuer-icon"/>
-                            <?= htmlspecialchars($issuer->name); ?>
+                            <input type="radio" name="<?php echo $code; ?>_issuer" value="<?php echo htmlspecialchars($issuer->id); ?>" id="issuer_<?php echo htmlspecialchars($issuer->id); ?>" class="radio">
+                            <img src="<?php echo $issuer->image->size2x; ?>" class="payment-issuer-icon"/>
+                            <?php echo htmlspecialchars($issuer->name); ?>
                         </li>
                     <?php endforeach; ?>
                     </ul>

--- a/app/design/frontend/base/default/template/mollie/mpm/payment/info/base.phtml
+++ b/app/design/frontend/base/default/template/mollie/mpm/payment/info/base.phtml
@@ -36,19 +36,19 @@
  * @see Mollie_Mpm_Block_Payment_Info_Base
  */
 ?>
-<p><?= $this->escapeHtml($this->getMethod()->getTitle()) ?></p>
+<p><?php echo $this->escapeHtml($this->getMethod()->getTitle()) ?></p>
 <?php if ($_specificInfo = $this->getSpecificInformation()): ?>
     <table>
         <tbody>
             <?php foreach ($_specificInfo as $_label => $_value): ?>
                 <tr>
-                    <th><strong><?= $this->escapeHtml($_label) ?>:</strong></th>
+                    <th><strong><?php echo $this->escapeHtml($_label) ?>:</strong></th>
                 </tr>
                 <tr>
-                    <td><?= nl2br(implode($this->getValueAsArray($_value, true), "\n")) ?></td>
+                    <td><?php echo nl2br(implode($this->getValueAsArray($_value, true), "\n")) ?></td>
                 </tr>
             <?php endforeach; ?>
         </tbody>
     </table>
 <?php endif; ?>
-<?= $this->getChildHtml() ?>
+<?php echo $this->getChildHtml() ?>

--- a/app/design/frontend/base/default/template/mollie/mpm/payment/info/paymentlink.phtml
+++ b/app/design/frontend/base/default/template/mollie/mpm/payment/info/paymentlink.phtml
@@ -36,22 +36,22 @@
  * @see Mollie_Mpm_Block_Payment_Info_Paymentlink
  */
 ?>
-<p><?= $this->escapeHtml($this->getMethod()->getTitle()) ?></p>
+<p><?php echo $this->escapeHtml($this->getMethod()->getTitle()) ?></p>
 <?php if (($this->getPaymentStatus() == 'created') && ($paymentUrl = $this->getPaymentLink())): ?>
-    <p><?= $paymentUrl; ?></p>
+    <p><?php echo $paymentUrl; ?></p>
 <?php endif; ?>
 <?php if ($_specificInfo = $this->getSpecificInformation()): ?>
     <table>
         <tbody>
             <?php foreach ($_specificInfo as $_label => $_value): ?>
                 <tr>
-                    <th><strong><?= $this->escapeHtml($_label) ?>:</strong></th>
+                    <th><strong><?php echo $this->escapeHtml($_label) ?>:</strong></th>
                 </tr>
                 <tr>
-                    <td><?= nl2br(implode($this->getValueAsArray($_value, true), "\n")) ?></td>
+                    <td><?php echo nl2br(implode($this->getValueAsArray($_value, true), "\n")) ?></td>
                 </tr>
             <?php endforeach; ?>
         </tbody>
     </table>
 <?php endif; ?>
-<?= $this->getChildHtml() ?>
+<?php echo $this->getChildHtml() ?>

--- a/modman
+++ b/modman
@@ -11,9 +11,7 @@ app/locale/fr_FR/Mollie_Mpm.csv            app/locale/fr_FR/Mollie_Mpm.csv
 app/locale/de_DE/Mollie_Mpm.csv            app/locale/de_DE/Mollie_Mpm.csv
 # app/design
 app/design/frontend/base/default/layout/mollie_mpm.xml            app/design/frontend/base/default/layout/mollie_mpm.xml
-app/design/frontend/base/default/template/mollie/mpm/payment/info.phtml            app/design/frontend/base/default/template/mollie/mpm/payment/info.phtml
-app/design/frontend/base/default/template/mollie/mpm/payment/label.phtml            app/design/frontend/base/default/template/mollie/mpm/payment/label.phtml
-app/design/frontend/base/default/template/mollie/mpm/payment/form.phtml            app/design/frontend/base/default/template/mollie/mpm/payment/form.phtml
+app/design/frontend/base/default/template/mollie/mpm/payment            app/design/frontend/base/default/template/mollie/mpm/payment
 app/design/frontend/base/default/template/mollie/mpm/loading.phtml            app/design/frontend/base/default/template/mollie/mpm/loading.phtml
 app/design/adminhtml/default/default/layout/mollie_mpm.xml            app/design/adminhtml/default/default/layout/mollie_mpm.xml
 app/design/adminhtml/default/default/template/mollie/mpm           app/design/adminhtml/default/default/template/mollie/mpm


### PR DESCRIPTION
Fixes to dont use shorthanded php syntax.
Fix for modman for installing through modman/composer.
