### PR TITLE
Added an index on mollie_transaction_id in the order table

### DIFF
--- a/app/code/community/Mollie/Mpm/etc/config.xml
+++ b/app/code/community/Mollie/Mpm/etc/config.xml
@@ -33,7 +33,7 @@
 <config>
     <modules>
         <Mollie_Mpm>
-            <version>5.0.3</version>
+            <version>5.0.4</version>
         </Mollie_Mpm>
     </modules>
     <global>

--- a/app/code/community/Mollie/Mpm/sql/mpm_setup/upgrade-5.0.3-5.0.4.php
+++ b/app/code/community/Mollie/Mpm/sql/mpm_setup/upgrade-5.0.3-5.0.4.php
@@ -1,0 +1,13 @@
+<?php
+
+/** @var Mage_Sales_Model_Resource_Setup $installer */
+$installer = $this;
+$installer->startSetup();
+
+$installer->getConnection()->addIndex(
+    $installer->getTable('sales/order'),
+    $this->getIdxName('sales/order', ['mollie_transaction_id']),
+    ['mollie_transaction_id']
+);
+
+$installer->endSetup();


### PR DESCRIPTION
It's used to lookup an order in the webhook controller action. I have a project with hundreds of thousands of orders. It takes a little too long to lookup an order in `Mollie_Mpm_Model_Mollie::getOrderIdByTransactionId()`.