### PR TITLE
Better error handling in webhook processing

### DIFF
--- a/app/code/community/Mollie/Mpm/controllers/ApiController.php
+++ b/app/code/community/Mollie/Mpm/controllers/ApiController.php
@@ -127,6 +127,9 @@ class Mollie_Mpm_ApiController extends Mage_Core_Controller_Front_Action
                 }
             } catch (\Exception $e) {
                 $this->mollieHelper->addToLog('error', $e->getMessage());
+                Mage::logException($e);
+                $this->getResponse()->setHeader('HTTP/1.1','503 Service Unavailable')->sendResponse();
+                exit;
             }
         }
     }


### PR DESCRIPTION
If anything goes wrong in handling a webhook call, Mollie needs to know about it so it can try again. For instance, I encountered a problem where the status request that gets sent to Mollie during the webhook handling timed out. The error got logged, but the controller returned HTTP Status 200 so Mollie never tried again. The order was still in state new, invoice never got created, order never got shipped, customer disappointed :(

What I did:
- Log an exception in Magento; it's serious enough to get noticed
- Send a 503 HTTP Status code to let Mollie try again later