### PR TITLE
Better error handling of payment redirect errors

### DIFF
--- a/app/code/community/Mollie/Mpm/controllers/ApiController.php
+++ b/app/code/community/Mollie/Mpm/controllers/ApiController.php
@@ -96,6 +96,7 @@ class Mollie_Mpm_ApiController extends Mage_Core_Controller_Front_Action
                 $this->mollieHelper->setError(self::REDIRECT_ERR_MSG);
                 $this->mollieHelper->addToLog('error', 'Missing Redirect Url');
                 $this->mollieHelper->restoreCart();
+                $this->_cancelUnprocessedOrder($order, 'Missing Redirect Url');
                 $this->_redirect('checkout/cart');
                 return;
             }
@@ -103,8 +104,35 @@ class Mollie_Mpm_ApiController extends Mage_Core_Controller_Front_Action
             $this->mollieHelper->setError(self::REDIRECT_ERR_MSG);
             $this->mollieHelper->addToLog('error', $e->getMessage());
             $this->mollieHelper->restoreCart();
+            $this->_cancelUnprocessedOrder($order, $e->getMessage());
             $this->_redirect('checkout/cart');
             return;
+        }
+    }
+
+    /**
+     * Cancel an order that has been sent to Mollie but somehow did not get a transaction id
+     *
+     * @param Mage_Sales_Model_Order $order
+     * @param string $message  If provided, add this message to the order status history comment
+     * @return void
+     */
+    protected function _cancelUnprocessedOrder(Mage_Sales_Model_Order $order, $message = null)
+    {
+        if (empty($order->getMollieTransactionId())) {
+            try {
+                $historyMessage = Mage::helper('mpm')->__('Canceled because an error occurred while redirecting the customer to Mollie');
+                if ($message) {
+                    $historyMessage .= ":<br>\n" . Mage::helper('core')->escapeHtml($message);
+                }
+                $order->cancel();
+                $order->addStatusHistoryComment($historyMessage);
+                $order->save();
+                $this->mollieHelper->addToLog('info', sprintf('Canceled order %s', $order->getIncrementId()));
+            } catch (Exception $e) {
+                $this->mollieHelper->addToLog('error', sprintf('Cannot cancel order %s: %s', $order->getIncrementId(), $e->getMessage()));
+                Mage::logException($e);
+            }
         }
     }
 


### PR DESCRIPTION
If something went wrong while redirecting the customer to Mollie (e.g. a 503 result from the Mollie API or a timeout occurred), the order can safely be canceled if the order did not get a transaction id assigned. Otherwise the order will be in state 'new' forever.
