### PR TITLE
Update config.xml

### DIFF
--- a/app/code/community/Mollie/Mpm/etc/config.xml
+++ b/app/code/community/Mollie/Mpm/etc/config.xml
@@ -174,7 +174,7 @@
                          This is to fix calculation errors when there are multiple custom totals -->
                     <tax_subtotal>
                         <after>nominal,subtotal,msrp,freeshipping</after>
-                        <before>tax_subtotal,weee,shipping,tax_shipping,discount,tax,grand_total</before>
+                        <before>weee,shipping,tax_shipping,discount,tax,grand_total</before>
                     </tax_subtotal>
                 </totals>
             </quote>


### PR DESCRIPTION
Remove wrong sorting as tax_subtotal can not be sorted before tax_subtotal. This results in a Circular dependecy when working with a fixed sorting for checkout totals in M1